### PR TITLE
Fix deprecated use of File::Temp->tempdir in tests

### DIFF
--- a/t/01_uri.t
+++ b/t/01_uri.t
@@ -11,7 +11,7 @@ use File::Temp;
 my $app = builder {
     enable 'Plack::Middleware::Session',
         store => Plack::Session::Store::File->new(
-            dir => File::Temp->tempdir( 'XXXXXXXX', TMPDIR => 1, CLEANUP => 1 )
+            dir => File::Temp->newdir( 'XXXXXXXX', TMPDIR => 1, CLEANUP => 1, TEMPDIR => 1 )
         ),
         state => Plack::Session::State::URI->new(
             session_key => 'sid'


### PR DESCRIPTION
File::Temp's tempdir() was never allowed to be used
as class method like this

  File::Temp->tempdir()

This wrong usage now throws an exception since File::Temp 0.23.

Additionally the implementation behind it made the wrong usage
behave like prefixing the given template with the default
tmp dir (usually /tmp).

The fix now uses "newdir" which is the designated drop-in
replacement for class method usage and provides it with
option TEMPDIR => 1, to make the tests behave exactly like
they originally did.
