### PR TITLE
2015 CPAN PR Challenge - PR #3 - Test HTML Parsing

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,8 @@ requires 'Plack';
 requires 'Plack::Middleware::Session';
 
 on test => sub {
+    requires 'HTML::TreeBuilder::XPath';
     requires 'HTTP::Request::Common';
+    requires 'Readonly';
     requires 'Test::More';
 };

--- a/t/02_html.t
+++ b/t/02_html.t
@@ -1,0 +1,276 @@
+use strict;
+use utf8;
+use warnings;
+
+use Data::Dumper;
+use File::Temp;
+use Fcntl qw/SEEK_END/;
+use HTTP::Request::Common;
+use HTML::TreeBuilder::XPath;
+use Plack::Builder;
+use Plack::Request;
+use Plack::Session::State::URI;
+use Plack::Session::Store::File;
+use Plack::Session;
+use Plack::Test;
+use Readonly;
+use Test::Simple tests => 10;
+
+sub escape_js_string {
+    my ($fake_form) = @_;
+
+    $fake_form =~ s/"/\\"/g;
+
+    return $fake_form;
+}
+
+Readonly::Scalar my $fake_form => '<form id="fake"></form>';
+Readonly::Scalar my $bad_attr => qq/data-breaking-attribute='$fake_form'/;
+Readonly::Scalar my $js_str_fake_form => escape_js_string($fake_form);
+Readonly::Scalar my $sid => 'sid';
+Readonly::Scalar my $base_re => qr/.*fake.*\n?.*$sid/;
+
+Readonly::Scalar my $html => <<EOF;
+<style type="text/css" $bad_attr>
+    /*css $fake_form */
+</style>
+<script type="text/javascript" $bad_attr>
+    <!--
+    var html = "$js_str_fake_form";
+    // $fake_form
+    /*js $fake_form */
+    -->
+</script>
+<form id="real" $bad_attr>
+    <!-- $fake_form -->
+    <label for="name" $bad_attr>Name:</label>
+    <input type="text" id="name" name="name" $bad_attr />
+</form>
+EOF
+
+my $app = builder {
+    my $dir = File::Temp->newdir('XXXXXXXX',
+            CLEANUP => 1,
+            TEMPDIR => 1,
+            TMPDIR => 1);
+
+    my $store = Plack::Session::Store::File->new(dir => $dir),
+    my $state = Plack::Session::State::URI->new(session_key => $sid);
+
+    enable 'Session', store => $store, state => $state;
+
+    sub {
+        my ($env) = @_;
+        my $req = Plack::Request->new($env);
+        my $session = Plack::Session->new($env);
+
+        if (defined $req->param('data')) {
+            $session->set('data', $req->param('data'));
+        }
+
+        my $data = $session->get('data');
+
+        $data = '' unless defined $data;
+
+        if (my $url = $req->param('url')) {
+            [
+                302,
+                ['Location', $url],
+                ['']
+            ];
+        } else {
+            [
+                200,
+                ['Content-Type', 'text/html; charset="UTF-8"'],
+                [$html]
+            ]
+        }
+    }
+};
+
+my ($log_fh, $log_fn);
+
+my $log_notice = 0;
+
+sub log_result {
+    my ($desc, @test_params) = @_;
+
+    unless ($log_notice) {
+        ($log_fh, $log_fn) =
+                File::Temp::tempfile(SUFFIX => 'Plack-Session-State-URI');
+
+        if (defined $log_fh) {
+            warn "# More verbose test results are being logged to ",
+                    "$log_fn.\n";
+            binmode $log_fh, ':utf8';
+        } else {
+            warn "# Failed to create temporary log file. ",
+                    "I would have logged more verbosely to it.\n";
+        }
+
+        $log_notice = 1;
+    }
+
+    unless (defined $log_fh) {
+        return;
+    }
+
+    print $log_fh "Description: $desc\n";
+
+    for(my ($i, $l) = (0, scalar @test_params); $i<$l; $i+=2) {
+        printf $log_fh "%s: %s\n", @test_params[$i, $i + 1];
+    }
+
+    print $log_fh "---\n";
+}
+
+sub test_result {
+    my ($desc, $result, $test_params, %named_params) = @_;
+
+    if ($named_params{negate}) {
+        $result = !$result;
+    }
+
+    if (!$result) {
+        log_result($desc, @$test_params);
+    }
+
+    ok $result, $desc;
+}
+
+sub test_lambda {
+    my ($desc, $content ,$lambda, %named_params) = @_;
+
+    my @test_params;
+
+    my $result = $lambda->($content, \@test_params);
+
+    {
+        chomp(my $dump = Data::Dumper->Dump([$result], ['result']));
+
+        push @test_params,
+                'Negated (Match is bad)' =>
+                        $named_params{negate} ? "yes" : "no",
+                'Result' => $dump;
+    }
+
+    test_result($desc, $result, \@test_params, %named_params);
+}
+
+sub test_match {
+    my ($desc, $content, $re, %named_params) = @_;
+
+    my @matches = $content =~ /($re)/;
+
+    my $test_params = do {
+        local $" = "», «";
+
+        [
+            'Regular expression' => "«$re»",
+            'Negated (Match is bad)' =>
+                    $named_params{negate} ? "yes" : "no",
+            'Matches' => "«@matches»"
+        ];
+    };
+
+    my $result = @matches;
+
+    test_result($desc, $result, $test_params, %named_params);
+}
+
+test_psgi $app, sub {
+    my ($cb) = @_;
+
+    my $res = $cb->(GET '/');
+
+    my $content = $res->content;
+
+    test_match(
+            'embedded HTML <form> in <style> attribute',
+            $content,
+            qr/<style$base_re/,
+            negate => 1);
+
+    test_match(
+            'embedded HTML <form> in CSS /**/ comment',
+            $content,
+            qr{/\*css$base_re},
+            negate => 1);
+
+    test_match(
+            'embedded HTML <form> in <script> attribute',
+            $content,
+            qr/<script$base_re/,
+            negate => 1);
+
+    test_match(
+            'embedded HTML <form> in JavaScript string',
+            $content,
+            qr/(var$base_re)/,
+            negate => 1);
+
+    test_match(
+            'embedded HTML <form> in JavaScript line comment',
+            $content,
+            qr{//$base_re},
+            negate => 1);
+
+    test_match(
+            'embedded HTML <form> in JavaScript block comment',
+            $content,
+            qr{/\*js$base_re},
+            negate => 1);
+
+    test_match(
+            'embedded HTML <form> in <form> attribute',
+            $content,
+            qr|
+                <form\ id="real"
+                .*?
+                <form\ id="fake">
+                [\n\s]*
+                <input
+                [^>]+
+                $sid
+            |x,
+            negate => 1);
+
+    test_match(
+            'embedded HTML <form> in <form> <label> attribute',
+            $content,
+            qr/<label$base_re/,
+            negate => 1);
+
+    test_match(
+            'embedded HTML <form> in <form> <input> attribute',
+            $content,
+            qr/<input.*id="name"$base_re/,
+            negate => 1);
+
+    test_lambda(
+            'real <form> has session identifier hidden <input>' =>
+            $content,
+            sub {
+                my ($content, $test_params) = @_;
+
+                my $parser = 'HTML::TreeBuilder::XPath';
+
+                push @$test_params, 'Parser' => $parser;
+
+                my $tree = $parser->new_from_content($content);
+
+                my $xpath = sprintf q{//form//input[@name='%s']}, $sid;
+
+                push @$test_params, 'XPath' => "«$xpath»";
+
+                my ($node) = $tree->findnodes($xpath);
+
+                unless ($node) {
+                    (my $indented = "«$content»") =~ s/^/' ' x 8/egm;
+
+                    push @$test_params, 'Content' => "\n$indented";
+                }
+
+                return $node;
+            });
+};


### PR DESCRIPTION
This pull request introduces a new test program that demonstrates the flaws in the regular expression used to parse the HTML. I am new to writing unit tests, test-driven development, and writing tests in Perl too. This is just a contrived program to show the alleged flaws. I tried to test it by hard-coding a "correct" transformation of the input HTML and verifying that the tests all pass. Hopefully that is still true after rebasing.

The test program uses File::Temp to log diagnostic information that would be noisy on the terminal. It might be helpful to understand why the tests are failing. Additionally, it might be useful to identify bugs in the tests themselves once work begins on replacing the regular expression with a proper parser.

I originally wanted to submit another branch that actually fixes these tests by using HTML::Parser and reimplmenting both of HTML::FillInForms and HTML::StickyQuery. I ran out of time and motivation this month so officially that patch won't make it into the challenge, but I'll still do my best to come up with something when time and motivation permit unless you beat me to it. Make sure you don't release after merging this branch until fixing the HTML parsing because the tests will fail and users will be quite annoyed when `make test` fails! Fix the tests before submitting a new release to CPAN!

If you have any trouble merging feel free to contact me! I'll do the work of rebasing for you so you don't have to fuss with it! Thanks!
