### PR TITLE
Fix regression: Add <input> back to <form>...

### DIFF
--- a/lib/Plack/Session/State/URI.pm
+++ b/lib/Plack/Session/State/URI.pm
@@ -77,7 +77,7 @@ sub _html_filter_body {
     my $name = $self->session_key;
     my $input = qq{<input type="hidden" name="$name" value="$id" />};
 
-    $body =~ s{(<form\s*.*?>)}{$1\n}isg;
+    $body =~ s{(<form\s*.*?>)}{$1\n$input}isg;
 
     my $sticky = HTML::StickyQuery->new;
 


### PR DESCRIPTION
My tidying up apparently led to a regression that removed the injected
&lt;input&gt; from &lt;form&gt; tags.

Doh! Evidently this module needs many more tests. :) Ironically it was
my HTML test program that detected this... Perhaps I can work on adding
additional tests in the future. Sorry for the confusion and trouble! I
can't believe I missed this. I'm actually sure that I caught this
earlier, but it must have gotten lost in rebasing or something... Who
knows.

**Append:** It appears that GitHub doesn't escape HTML... That seems... <script type="text/javascript">alert("VERY VERY BAD?");</script> bad. Instead they seem to strip it out (so you can't see the &lt;script&gt; tag that I attempted to inject before this sentence). I guess there's nothing to fear, but it seems pretty damn incompetent. Like Microsoft quality...
